### PR TITLE
Add sx_puts, sx_fputs

### DIFF
--- a/src/examples/test.c
+++ b/src/examples/test.c
@@ -1,13 +1,11 @@
 #if defined(WIN32) || defined(WIN64)
 #pragma warning(disable : 4996)
 #include <conio.h>
+#else
+#define _getch getchar
 #endif
 
 #include <stdio.h>
-#ifdef linux
-//#include <curses.h>
-#define _getch getchar
-#endif
 #include <ctype.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/examples/test.c
+++ b/src/examples/test.c
@@ -599,7 +599,7 @@ void test_NodeXPath(void)
 	XMLNode_add_child(&node, &node1);
 
 	buf = NULL;
-	sx_printf(XMLNode_get_XPath(&node1, &buf, true));
+	sx_puts(XMLNode_get_XPath(&node1, &buf, true));
 	free(buf);
 }
 

--- a/src/sxmlc.c
+++ b/src/sxmlc.c
@@ -856,12 +856,12 @@ static int _count_new_char_line(const SXML_CHAR* str, int nb_char_tab, int cur_s
 static int _print_formatting(const XMLNode* node, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, int nb_char_tab, int cur_sz_line)
 {
 	if (tag_sep != NULL) {
-		sx_fprintf(f, tag_sep);
+		sx_fputs(tag_sep, f);
 		cur_sz_line = _count_new_char_line(tag_sep, nb_char_tab, cur_sz_line);
 	}
 	if (child_sep != NULL) {
 		for (node = node->father; node != NULL; node = node->father) {
-			sx_fprintf(f, child_sep);
+			sx_fputs(child_sep, f);
 			cur_sz_line = _count_new_char_line(child_sep, nb_char_tab, cur_sz_line);
 		}
 	}
@@ -915,13 +915,13 @@ static int _XMLNode_print_header(const XMLNode* node, FILE* f, const SXML_CHAR* 
 			cur_sz_line = _print_formatting(node, f, tag_sep, child_sep, nb_char_tab, cur_sz_line);
 			/* Add extra separator, as if new line was a child of the previous one */
 			if (child_sep != NULL) {
-				sx_fprintf(f, child_sep);
+				sx_fputs(child_sep, f);
 				cur_sz_line = _count_new_char_line(child_sep, nb_char_tab, cur_sz_line);
 			}
 		}
 		/* Attribute name */
 		if (attr_sep != NULL) {
-			sx_fprintf(f, attr_sep);
+			sx_fputs(attr_sep, f);
 			cur_sz_line = _count_new_char_line(attr_sep, nb_char_tab, cur_sz_line);
 			sx_fprintf(f, C2SX("%s="), node->attributes[i].name);
 		} else
@@ -2269,7 +2269,7 @@ int fprintHTML(FILE* f, SXML_CHAR* str)
 			if (*p != HTML_SPECIAL_DICT[i].chr)
 				continue;
 			if (f != NULL)
-				sx_fprintf(f, HTML_SPECIAL_DICT[i].html);
+				sx_fputs(HTML_SPECIAL_DICT[i].html, f);
 			n += HTML_SPECIAL_DICT[i].html_len;
 			break;
 		}

--- a/src/sxmlc.h
+++ b/src/sxmlc.h
@@ -56,6 +56,8 @@ extern "C" {
 	#define sx_sprintf swprintf
 	#define sx_fgetc fgetwc
 	#define sx_fputc fputwc
+	#define sx_puts putws
+	#define sx_fputs fputws
 	#define sx_isspace iswspace
 	#if defined(WIN32) || defined(WIN64)
 		#define sx_fopen _wfopen
@@ -82,6 +84,8 @@ extern "C" {
 	#define sx_sprintf sprintf
 	#define sx_fgetc fgetc
 	#define sx_fputc fputc
+	#define sx_puts puts
+	#define sx_fputs fputs
 	#define sx_isspace(ch) isspace((int)ch)
 	#define sx_fopen fopen
 	#define sx_fclose fclose


### PR DESCRIPTION
This pull request adds two defines to `sxmlc.h`:
- `sx_puts`
- `sx_fputs`

Using `sx_fputs` in place of `sx_fprintf` fixes a couple of compiler warnings about potentially insecure format string usage.