### PR TITLE
Improved CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13)
+
+option(BUILD_SHARED_LIBS "Build sxmlc as shared library instead of static" ON)
+
+add_library(sxmlc src/sxmlc.c src/sxmlsearch.c)
+target_include_directories(sxmlc PUBLIC src/)
+
+if (BUILD_SHARED_LIBS)
+    set_target_properties (sxmlc PROPERTIES VERSION 4.5.1 SOVERSION 4)
+    include(GNUInstallDirs)
+    install(TARGETS sxmlc LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    # manually install headder files
+    install(FILES src/sxmlc.h src/sxmlsearch.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -1,4 +1,0 @@
-cmake_minimum_required(VERSION 3.13)
-
-add_library(sxmlc STATIC src/sxmlc.c src/sxmlsearch.c)
-target_include_directories(sxmlc PUBLIC src/)


### PR DESCRIPTION
Improve CMake support to use the library with the Yocto build system.
* Renamed CmakeLists.txt to CMakeLists.txt, case matters on Linux.
* Use BUILD_SHARED_LIBS from CMake to specify if building shared or
  static library.
* Add install for shared library.

By default CMake will build a shared library. To build a static library just set CMake variable `BUILD_SHARED_LIBS` to off.