### PR TITLE
fix warning assignment discards ‘const’ qualifier with GCC 16

### DIFF
--- a/src/sxmlc.c
+++ b/src/sxmlc.c
@@ -1231,7 +1231,7 @@ static TagType _parse_special_tag(const SXML_CHAR* str, int len, _TAG* tag, XMLN
  */
 TagType XML_parse_1string(const SXML_CHAR* str, XMLNode* xmlnode)
 {
-	SXML_CHAR *p;
+	const SXML_CHAR *p;
 	XMLAttribute* pt;
 	int n, nn, len, rc, tag_end = 0;
 


### PR DESCRIPTION
We have a warning on GCC16
```
                       ^~~~~~~~~~~~~
sxmlc.c: In function ‘XML_parse_1string’:
sxmlc.c:1317:19: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1317 |                 p = sx_strchr(str+n, C2SX('='));
 ```

this commit just add const qualifier on p declaration (line 1233)

``` cpp
	SXML_CHAR *p;
```
become
```
	const SXML_CHAR *p;
```