### PR TITLE
Fix XMLNode_copy() never copying node text

### DIFF
--- a/src/sxmlc.c
+++ b/src/sxmlc.c
@@ -339,7 +339,7 @@ int XMLNode_copy(XMLNode* dst, const XMLNode* src, int copy_children)
 	}
 
 	/* Text */
-	if (dst->text != NULL) {
+	if (src->text != NULL) {
 		dst->text = sx_strdup(src->text);
 		if (dst->text == NULL) goto copy_err;
 	}


### PR DESCRIPTION
`XMLNode_copy()` checks `dst->text != NULL` before duplicating the text field, but `dst` was just reset by the `XMLNode_free(dst)` call a few lines above, so `dst->text` is always `NULL` at that point. As a result the source node's text is never copied.

The check should be on `src->text`, mirroring the correct pattern already used for the `tag` field immediately above it:

```c
/* Tag */
if (src->tag != NULL) {
    dst->tag = sx_strdup(src->tag);
    ...
}

/* Text */
if (dst->text != NULL) {   /* always false here: dst was just freed */
    dst->text = sx_strdup(src->text);
    ...
}
```

**Repro:** create a node with `XMLNode_new(TAG_FATHER, "foo", "hello world")` then call `XMLNode_dup(node, FALSE)` (which calls `XMLNode_copy` internally) — the duplicated node's `text` field comes back `NULL` instead of `"hello world"`.

**Fix:** change the condition to `if (src->text != NULL)`, consistent with the Tag block.

This only affects callers that explicitly use the `XMLNode_copy`/`XMLNode_dup` API on a node that already has text set (e.g. `src/examples/test.c`); the normal SAX/DOM parsing path attaches text via a separate `XMLNode_set_text` call and does not go through `XMLNode_copy`, so there is no regression risk to normal parsing.